### PR TITLE
Add autocomplete for the otp-code, so password managers automatically…

### DIFF
--- a/core/components/twofactorx/src/Plugins/Events/OnManagerLoginFormRender.php
+++ b/core/components/twofactorx/src/Plugins/Events/OnManagerLoginFormRender.php
@@ -17,7 +17,7 @@ class OnManagerLoginFormRender extends Plugin
             $output = '<div class="x-form-item login-form-item" style="clear:left; padding-top: 10px">'
                 . '<label for="modx-login-code">' . $this->modx->lexicon('twofactorx.authkey') . '</label>'
                 . '<div class="x-form-element login-form-element">'
-                . '<input type="text" name="code" id="modx-login-code" value="" tabindex="2" autocomplete="off" maxlength="6" class="x-form-text x-form-field"/>'
+                . '<input type="text" name="code" id="modx-login-code" value="" tabindex="2" autocomplete="one-time-code" maxlength="6" class="x-form-text x-form-field"/>'
                 . '</div>'
                 . '</div>';
             $this->modx->event->_output = $output;


### PR DESCRIPTION
Add autocomplete for the otp-code, so password managers automatically fill the otp-field

Tested on mac with:
1Password for Mac 8.10.24 (81024044)
Safari Version 17.3 (19617.2.4.11.8)
Chrome Version 121.0.6167.139 (Official Build) (arm64)
Firefox 122.0.1 (64-bit)