### PR TITLE
Added QR code as attachment

### DIFF
--- a/core/components/twofactorx/lexicon/de/email.inc.php
+++ b/core/components/twofactorx/lexicon/de/email.inc.php
@@ -22,6 +22,5 @@ $_lang['twofactorx.notifyemail_body'] = '<p>Hallo [[+username]],</p>
 $_lang['twofactorx.notifyemail_subject'] = 'Die Zwei-Faktor-Authentifizierung bei der Anmeldung wurde aktiviert';
 $_lang['twofactorx.qremail_body'] = '<p>Hallo [[+username]],</p>
 <p>Um die Zwei-Faktor-Authentifizierung zu nutzen, benötigen Sie ein unterstütztes Gerät oder eine Anwendung, die ein zeitbasiertes Einmal-Passwort (TOTP) zu generieren, z. B. Google Authenticator, Authy oder 1Password. Öffnen Sie die Authentifizierungsanwendung und scannen den bereitgestellten QR-Code. Sobald dieser Vorgang erfolgreich abgeschlossen ist, wird in der Authentifizierungsanwendung alle 30 Sekunden ein neuer Authentifizierungsschlüssel angezeigt. Dieser Schlüssel wird nun beim Einloggen benötigt.</p>
-<p><img src="[[+qrsvg]]" alt="QR Code"/></p>
 <p>Secret: [[+secret]]</p>';
 $_lang['twofactorx.qremail_subject'] = 'Ihr QR-Code für die Zwei-Faktor-Authentifizierung';

--- a/core/components/twofactorx/lexicon/en/email.inc.php
+++ b/core/components/twofactorx/lexicon/en/email.inc.php
@@ -22,6 +22,5 @@ $_lang['twofactorx.notifyemail_body'] = '<p>Hello [[+username]],</p>
 $_lang['twofactorx.notifyemail_subject'] = 'Two-factor authentication has been activated in the login';
 $_lang['twofactorx.qremail_body'] = '<p>Hello [[+username]],</p>
 <p>To use the two-factor authentication, you need a supported device or application that can generate a time-based one-time password, e.g. Google Authenticator, Authy or 1Password. Open the authentication application and scan the QR code provided. Once this process has been successfully completed, a new authentication key will be displayed in the authentication application every 30 seconds. This key is now required when logging in.</p>
-<p><img src="[[+qrsvg]]" alt="QR Code"/></p>
 <p>Secret: [[+secret]]</p>';
 $_lang['twofactorx.qremail_subject'] = 'Your Two-factor authentication QR-code';

--- a/core/components/twofactorx/lexicon/nl/default.inc.php
+++ b/core/components/twofactorx/lexicon/nl/default.inc.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Standaard Lexicon Ingangen voor TwoFactorX
+ *
+ * @package twofactorx
+ * @subpackage lexicon
+ */
+$_lang['twofactorx'] = 'TwoFactorX';
+$_lang['twofactorx.authkey'] = 'Authenticatiesleutel';
+$_lang['twofactorx.btn_changestatus'] = 'Status Wijzigen';
+$_lang['twofactorx.btn_changestatus_confirm'] = 'Weet u zeker dat u de authenticatiestatus voor deze gebruiker wilt wijzigen?';
+$_lang['twofactorx.btn_disable'] = 'Authenticator Uitschakelen';
+$_lang['twofactorx.btn_emailinstructions'] = 'Instructies E-mailen Naar Gebruiker';
+$_lang['twofactorx.btn_emailinstructions_confirm'] = 'Weet u zeker dat u de instructies per e-mail naar deze gebruiker wilt sturen?';
+$_lang['twofactorx.btn_emailqr'] = 'QR-code E-mailen Naar Gebruiker';
+$_lang['twofactorx.btn_emailqr_confirm'] = 'Weet u zeker dat u het geheim van de authenticator per e-mail naar deze gebruiker wilt sturen? Dit is de minst veilige manier om het geheim naar de gebruiker te verzenden!';
+$_lang['twofactorx.btn_enable'] = 'Authenticator Inschakelen';
+$_lang['twofactorx.btn_resetsecret'] = 'Secret Resetten';
+$_lang['twofactorx.btn_resetsecret_confirm'] = 'Weet u zeker dat u het geheim van de authenticator wilt resetten? U moet de gebruiker een nieuw geheim verstrekken!';
+$_lang['twofactorx.onetime_notification'] = 'Dit is een eenmalige login zonder gebruik van de tweede factor. Scan de QR-code of sla het geheim op in een twee-factor applicatie om in de toekomst in te kunnen loggen op deze manager. U wordt automatisch uitgelogd uit de manager na 60 seconden.';
+$_lang['twofactorx.disabled'] = 'Uitgeschakeld';
+$_lang['twofactorx.enabled'] = 'Ingeschakeld';
+$_lang['twofactorx.enterkey'] = 'Voer de authenticatiesleutel in!';
+$_lang['twofactorx.invalidcode'] = 'Ongeldige authenticatiesleutel.';
+$_lang['twofactorx.invaliddata'] = 'Het laden van gebruikersauthenticatiegegevens is mislukt.';
+$_lang['twofactorx.invalidformat'] = 'Ongeldig formaat van de authenticatiesleutel, 6 cijfers verwacht!';
+$_lang['twofactorx.lbl_qrcode'] = 'QR-code';
+$_lang['twofactorx.lbl_secret'] = 'Secret';
+$_lang['twofactorx.lbl_status'] = 'Status';
+$_lang['twofactorx.lbl_uri'] = 'URI';
+$_lang['twofactorx.secret_reset'] = 'Secret gereset.';
+$_lang['twofactorx.status_changed'] = 'Status gewijzigd.';
+$_lang['twofactorx.usertab'] = 'TwoFactorX';
+$_lang['twofactorx.usertab_desc'] = 'Hier kunt u de TwoFactorX-gebruikersopties beheren.';

--- a/core/components/twofactorx/lexicon/nl/email.inc.php
+++ b/core/components/twofactorx/lexicon/nl/email.inc.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * E-mail Lexicon Ingangen voor TwoFactorX
+ *
+ * @package twofactorx
+ * @subpackage lexicon
+ */
+$_lang['twofactorx.email_fail'] = 'E-mail verzenden mislukt.';
+$_lang['twofactorx.email_success'] = 'E-mail succesvol verzonden.';
+$_lang['twofactorx.notifyemail_body'] = '<p>Hallo [[+username]],</p>
+<p>U ontvangt deze e-mail omdat 2FA is geactiveerd voor uw account. Om 2FA te gebruiken, heeft u een ondersteund apparaat of een applicatie nodig die een tijdgebonden eenmalig wachtwoord (TOTP) genereert, zoals Google Authenticator, Authy of 1Password. Zonder een authenticatiesleutel kunt u slechts één keer inloggen. Als u succesvol bent ingelogd, ontvangt u alleen uw QR-code en wordt u direct uitgelogd.</p>
+<p>Open de authenticatie-applicatie en scan de verstrekte QR-code. Zodra dit proces succesvol is voltooid, wordt er elke 30 seconden een nieuwe authenticatiesleutel weergegeven in de authenticatie-applicatie.</p>
+<p><strong>Let op. De QR-code is slechts 60 seconden zichtbaar op het scherm.</strong></p>
+<hr/>
+<div style="margin-top: 0px;">
+<h4>De applicatie instellen</h4>
+<ol>
+<li>Open de authenticatie-applicatie.</li>
+<li>Om uw ondersteunde apparaat of applicatie aan uw account te koppelen, moet u de QR-code scannen of de naam en geheime sleutel in de applicatie invoeren.</li>
+</ol>
+</div>';
+$_lang['twofactorx.notifyemail_subject'] = '2FA is geactiveerd bij het inloggen';
+$_lang['twofactorx.qremail_body'] = '<p>Hallo [[+username]],</p>
+<p>Om de 2FA te gebruiken, heeft u een ondersteund apparaat of een applicatie nodig die een tijdgebonden eenmalig wachtwoord kan genereren, zoals Google Authenticator, Authy of 1Password. Open de authenticatie-applicatie en scan de verstrekte QR-code. Zodra dit proces succesvol is voltooid, wordt er elke 30 seconden een nieuwe authenticatiesleutel weergegeven in de authenticatie-applicatie. Deze sleutel is nu vereist bij het inloggen.</p>
+<p>Geheim: [[+secret]]</p>';
+$_lang['twofactorx.qremail_subject'] = 'Uw 2FA QR-code';

--- a/core/components/twofactorx/lexicon/nl/permissions.inc.php
+++ b/core/components/twofactorx/lexicon/nl/permissions.inc.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Permissions Lexicon Entries for TwoFactorX
+ *
+ * @package twofactorx
+ * @subpackage lexicon
+ */
+$_lang['twofactorx.permission.twofactorx_edit_desc'] = 'To update the TwoFactorX data in the user edit page.';

--- a/core/components/twofactorx/lexicon/nl/properties.inc.php
+++ b/core/components/twofactorx/lexicon/nl/properties.inc.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Properties Lexicon Entries for TwoFactorX
+ *
+ * @package twofactorx
+ * @subpackage lexicon
+ */
+$_lang['twofactorx.twofactorxlogin.twofactorxErrorMsg'] = 'Alternative error message, if the authentication code does not match.';
+$_lang['twofactorx.userqrcode.placeholderPrefix'] = 'The prefix for the placeholders set by the snippet.';
+$_lang['twofactorx.userqrcode.userid'] = 'The id of the user the QR code is created for.';

--- a/core/components/twofactorx/lexicon/nl/setting.inc.php
+++ b/core/components/twofactorx/lexicon/nl/setting.inc.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Setting Lexicon Entries for TwoFactorX
+ *
+ * @package twofactorx
+ * @subpackage lexicon
+ */
+$_lang['setting_twofactorx.enable_onetime'] = 'Eenmalige Inlog Inschakelen';
+$_lang['setting_twofactorx.enable_onetime_desc'] = 'Als u eenmalige inlog inschakelt, mogen gebruikers één keer inloggen om hun secret op te halen.';
+$_lang['setting_twofactorx.debug'] = 'Debug';
+$_lang['setting_twofactorx.debug_desc'] = 'Log debug-informatie in het MODX-foutlogboek.';
+$_lang['setting_twofactorx.enable_2fa'] = '2FA Inschakelen';
+$_lang['setting_twofactorx.enable_2fa_desc'] = 'Als u 2FA inschakelt, wordt de managerlogin beveiligd met een extra TOTP-authenticatiecode.';
+$_lang['setting_twofactorx.encryption_key'] = 'Versleutelingssleutel';
+$_lang['setting_twofactorx.encryption_key_desc'] = 'Versleutelingssleutel die wordt gebruikt voor de versleuteling van de 2FA-gegevens. Niet wijzigen.';
+$_lang['setting_twofactorx.issuer'] = 'QR-code Uitgever';
+$_lang['setting_twofactorx.issuer_desc'] = 'Geef de waarde op van de uitgever in de QR-code. De standaardwaarde is de systeeminstelling site_name.';
+$_lang['setting_twofactorx.show_in_profile'] = 'Toon secret in Gebruikersprofiel';
+$_lang['setting_twofactorx.show_in_profile_desc'] = 'Sta beheerdersgebruikers toe om de QR-code en het geheim voor 2FA in hun gebruikersprofiel te zien.';
+

--- a/core/components/twofactorx/processors/mgr/email/instructions.class.php
+++ b/core/components/twofactorx/processors/mgr/email/instructions.class.php
@@ -20,8 +20,8 @@ class TwoFactorXEmailInstructionsProcessor extends Processor
         $settings = $this->twofactorx->getDecryptedSettings();
         if ($settings) {
             $user = $this->modx->getObject('modUser', $userid);
-            $mgrLanguage = $user->getOption('manager_language');
-            $mgrLanguage = $mgrLanguage ?:  $this->modx->getOption('cultureKey');
+            $mgrLanguage = $this->modx->getOption('cultureKey');
+            $mgrLanguage = $mgrLanguage ?: $user->getOption('manager_language');
             $this->modx->lexicon->load($mgrLanguage . ':twofactorx:email');
             $subject = $this->modx->lexicon('twofactorx.notifyemail_subject');
             $body = $this->modx->lexicon('twofactorx.notifyemail_body', [

--- a/core/components/twofactorx/processors/mgr/email/secret.class.php
+++ b/core/components/twofactorx/processors/mgr/email/secret.class.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Email Secret
+ * Email Secret with QR Code as Attachment
  *
  * @package twofactorx
  * @subpackage processors
@@ -10,8 +10,10 @@ use Endroid\QrCode\Builder\Builder;
 use Endroid\QrCode\Encoding\Encoding;
 use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelMedium;
 use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeModeNone;
-use Endroid\QrCode\Writer\SvgWriter;
+use Endroid\QrCode\Writer\PngWriter;
 use TreehillStudio\TwoFactorX\Processors\Processor;
+use MODX\Revolution\Mail\modMail;
+use MODX\Revolution\Mail\modPHPMailer;
 
 class TwoFactorXEmailSecretProcessor extends Processor
 {
@@ -31,10 +33,8 @@ class TwoFactorXEmailSecretProcessor extends Processor
             ]);
 
             $qrcode = Builder::create()
-                ->writer(new SvgWriter())
-                ->writerOptions([
-                    SvgWriter::WRITER_OPTION_EXCLUDE_XML_DECLARATION => true
-                ])
+                ->writer(new PngWriter())
+                ->writerOptions([])
                 ->data($this->twofactorx->getUri($settings['accountname'], $settings['secret'], $settings['issuer']))
                 ->encoding(new Encoding('UTF-8'))
                 ->errorCorrectionLevel(new ErrorCorrectionLevelMedium())
@@ -42,7 +42,9 @@ class TwoFactorXEmailSecretProcessor extends Processor
                 ->margin(0)
                 ->roundBlockSizeMode(new RoundBlockSizeModeNone())
                 ->build();
-            $qrsvg = $qrcode->getString();
+            
+            $tempFile = tempnam(sys_get_temp_dir(), 'qrcode_') . '.png';
+            file_put_contents($tempFile, $qrcode->getString());
 
             $user = $this->modx->getObject('modUser', $userid);
             $mgrLanguage = $user->getOption('manager_language');
@@ -54,22 +56,67 @@ class TwoFactorXEmailSecretProcessor extends Processor
             $body = $this->modx->lexicon('twofactorx.qremail_body', [
                 'username' => $this->twofactorx->userName,
                 'secret' => $settings['secret'],
-                'qrsvg' => 'data:image/svg+xml,' . rawurlencode($qrsvg),
             ]);
 
             $body = '<html><body>' . $body . '</body></html>';
 
-            if (!$user->sendEmail($body, [
-                'subject' => $subject
+            $attachments = ['path' => $tempFile, 'name' => 'qrcode.png', 'mime' => 'image/png'];
+
+            if (!$this->sendEmail($body, $user, [
+                'subject' => $subject,
+                'attachments' => $attachments
             ])) {
                 $errorInfo = $this->modx->mail->mailer->ErrorInfo;
+                $this->modx->log(xPDO::LOG_LEVEL_ERROR, 'Failed to send mail: ' . $errorInfo);
                 return $this->modx->error->failure($this->modx->lexicon('twofactorx.email_fail') . $errorInfo);
             }
-
             return $this->modx->error->success($this->modx->lexicon('twofactorx.email_success'));
         } else {
             return $this->modx->error->failure($this->modx->lexicon('twofactorx.invaliddata'));
         }
+    }
+    
+    /**
+     *  Sends an email with the QR code as an attachment
+     *
+     * @param string $message
+     * @param modUser $user
+     * @param array $options
+     * @return void
+     */
+    public function sendEmail($message, $user, $options = []) {  
+         /** @var modUserProfile $profile */
+         $profile = $user->getOne('Profile');
+         /** @var modPHPMailer $mail */
+         $mail = $this->modx->getService('mail', modPHPMailer::class);
+ 
+         if (!$profile || !$mail) {
+             return false;
+         }
+         $mail->set(modMail::MAIL_BODY, $message);
+         $mail->set(modMail::MAIL_FROM, $this->modx->getOption('from', $options, $this->modx->getOption('emailsender')));
+         $mail->set(modMail::MAIL_FROM_NAME,
+             $this->modx->getOption('fromName', $options, $this->modx->getOption('site_name')));
+         $mail->set(modMail::MAIL_SENDER,
+             $this->modx->getOption('sender', $options, $this->modx->getOption('emailsender')));
+         $mail->set(modMail::MAIL_SUBJECT,
+             $this->modx->getOption('subject', $options['subject'], $this->modx->lexicon('twofactorx.qremail_subject')));
+         $mail->address('to', $profile->get('email'), $profile->get('fullname'));
+         $mail->address('reply-to', $this->modx->getOption('sender', $options, $this->modx->getOption('emailsender')));
+         
+         $mail->attach(
+            $options['attachments']['path'],
+            $options['attachments']['name']
+        );
+
+         $mail->setHTML($this->modx->getOption('html', $options, true));
+         if (!$sent = $mail->send()) {
+             $err = $this->modx->lexicon('error_sending_email_to') . $profile->get('email') . ': ' . $mail->mailer->ErrorInfo;
+             $this->modx->log(modx::LOG_LEVEL_ERROR, $err);
+         }
+         $this->modx->mail->reset();
+            
+        return $sent;
     }
 }
 

--- a/core/components/twofactorx/processors/mgr/email/secret.class.php
+++ b/core/components/twofactorx/processors/mgr/email/secret.class.php
@@ -47,8 +47,8 @@ class TwoFactorXEmailSecretProcessor extends Processor
             file_put_contents($tempFile, $qrcode->getString());
 
             $user = $this->modx->getObject('modUser', $userid);
-            $mgrLanguage = $user->getOption('manager_language');
-            $mgrLanguage = $mgrLanguage ?: $this->modx->getOption('cultureKey');
+            $mgrLanguage = $this->modx->getOption('cultureKey');
+            $mgrLanguage = $mgrLanguage ?: $user->getOption('manager_language');
 
             $this->modx->lexicon->load($mgrLanguage . ':twofactorx:email');
             $subject = $this->modx->lexicon('twofactorx.qremail_subject');


### PR DESCRIPTION
I have made adjustments to remove the QR code SVG from the email because platforms like Gmail block and strip SVGs from emails for security reasons. 

As a result, the QR code was not displayed in emails on platforms like Gmail, though it may have worked in other email clients. To resolve this, we have decided to include the QR code as an attachment instead. We tested this approach on various platforms, and it works as expected.

Additionally, I have added Dutch (NL) lexicons for TwoFactorX

_SVG/PNG in Gmail:_
![Screenshot 2025-02-17 at 14 40 31](https://github.com/user-attachments/assets/0eff97a0-e4df-49c1-b97b-c71cd70b1b9a)

Let me know if you have any questions/feedback! 